### PR TITLE
#20 - MappedSuperClass 사용

### DIFF
--- a/jpa-study/src/main/java/com/hellojpa/BaseEntity.java
+++ b/jpa-study/src/main/java/com/hellojpa/BaseEntity.java
@@ -1,0 +1,48 @@
+package com.hellojpa;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class BaseEntity {
+    @Column(name="INSERT_MEMBER")
+    private String createdBy;
+    private LocalDateTime createdDate;
+    @Column(name="UPDATE_MEMBER")
+    private String lastModifiedBy;
+    private LocalDateTime lastModifiedDate;
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(LocalDateTime createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public String getLastModifiedBy() {
+        return lastModifiedBy;
+    }
+
+    public void setLastModifiedBy(String lastModifiedBy) {
+        this.lastModifiedBy = lastModifiedBy;
+    }
+
+    public LocalDateTime getLastModifiedDate() {
+        return lastModifiedDate;
+    }
+
+    public void setLastModifiedDate(LocalDateTime lastModifiedDate) {
+        this.lastModifiedDate = lastModifiedDate;
+    }
+}

--- a/jpa-study/src/main/java/com/hellojpa/Item.java
+++ b/jpa-study/src/main/java/com/hellojpa/Item.java
@@ -16,7 +16,6 @@ import javax.persistence.InheritanceType;
 public abstract class Item {
     @Id @GeneratedValue
     private Long id;
-
     private String name;
     private int price;
 

--- a/jpa-study/src/main/java/com/hellojpa/JpaMain.java
+++ b/jpa-study/src/main/java/com/hellojpa/JpaMain.java
@@ -1,5 +1,6 @@
 package com.hellojpa;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import javax.persistence.EntityManager;
@@ -16,17 +17,16 @@ public class JpaMain {
         tx.begin();
         try{
             Movie movie = new Movie();
-            movie.setDirector("aaa");
-            movie.setActor("bbb");
-            movie.setName("바람과함께 사라짐ㅋ");
             movie.setPrice(10000);
+            movie.setName("바람과사라짐");
+            movie.setDirector("이정현");
+            movie.setActor("응애");
             em.persist(movie);
             em.flush();
             em.clear();
-
-            Movie movie1 = em.find(Movie.class, movie.getId());
-            System.out.println("item = " + movie1.getName());
-
+            Movie findItem = (Movie) em.find(Item.class, 1L);
+            System.out.println(findItem.getDirector());
+            
             tx.commit();
         }catch(Exception e){
             tx.rollback();

--- a/jpa-study/src/main/java/com/hellojpa/Member.java
+++ b/jpa-study/src/main/java/com/hellojpa/Member.java
@@ -1,5 +1,6 @@
 package com.hellojpa;
 
+import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -9,7 +10,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 
 @Entity
-public class Member {
+public class Member extends BaseEntity{
     @Id @GeneratedValue
     @Column(name="MEMBER_ID")
     private Long id;
@@ -23,6 +24,7 @@ public class Member {
     @ManyToOne
     @JoinColumn(name="TEAM_ID")
     private Team team;
+
     public Member() {
     }
 


### PR DESCRIPTION
this closes #20 
엔티티에서 필수로 들어가야하는 컬럼들을
각 엔티티가 변수로 가질 필요 없이
BaseEntity 를 사용해 상속받게 하면 된다.