### PR TITLE
#30 - 값타입1, 불변객체

### DIFF
--- a/jpa-study/src/main/java/com/hellojpa/Address.java
+++ b/jpa-study/src/main/java/com/hellojpa/Address.java
@@ -1,0 +1,43 @@
+package com.hellojpa;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class Address {
+    private String city;
+    private String street;
+    private String zipcode;
+
+    public Address() {
+    }
+
+    public Address(String city, String street, String zipcode) {
+        this.city = city;
+        this.street = street;
+        this.zipcode = zipcode;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+
+    public String getZipcode() {
+        return zipcode;
+    }
+
+    public void setZipcode(String zipcode) {
+        this.zipcode = zipcode;
+    }
+}

--- a/jpa-study/src/main/java/com/hellojpa/Address.java
+++ b/jpa-study/src/main/java/com/hellojpa/Address.java
@@ -21,23 +21,25 @@ public class Address {
         return city;
     }
 
-    public void setCity(String city) {
-        this.city = city;
-    }
 
     public String getStreet() {
         return street;
     }
 
-    public void setStreet(String street) {
-        this.street = street;
-    }
 
     public String getZipcode() {
         return zipcode;
     }
 
-    public void setZipcode(String zipcode) {
+    private void setCity(String city) {
+        this.city = city;
+    }
+
+    private void setStreet(String street) {
+        this.street = street;
+    }
+
+    private void setZipcode(String zipcode) {
         this.zipcode = zipcode;
     }
 }

--- a/jpa-study/src/main/java/com/hellojpa/JpaMain.java
+++ b/jpa-study/src/main/java/com/hellojpa/JpaMain.java
@@ -18,19 +18,20 @@ public class JpaMain {
         EntityTransaction tx = em.getTransaction();
         tx.begin();
         try{
-            Child child1 = new Child();
-            Child child2 = new Child();
-            Parent parent = new Parent();
-            parent.addChild(child1);
-            parent.addChild(child2);
-            em.persist(parent);
+            Address address = new Address("city","street","zipcode");
+            Member member = new Member();
+            member.setUserName("hello1");
+            member.setHomeAddress(address);
+            em.persist(member);
 
-            em.flush();
-            em.clear();
+            Address copyAddress = new Address(address.getCity(), address.getStreet(),
+                address.getZipcode());
+            Member member2 = new Member();
+            member2.setUserName("hello1");
+            member2.setHomeAddress(copyAddress);
+            em.persist(member2);
 
-            Parent findParent = em.find(Parent.class, parent.getId());
-            System.out.println(findParent.getChildList().getClass());
-
+            member.getHomeAddress().setCity("newCity");
             tx.commit();
         }catch(Exception e){
             e.printStackTrace();

--- a/jpa-study/src/main/java/com/hellojpa/JpaMain.java
+++ b/jpa-study/src/main/java/com/hellojpa/JpaMain.java
@@ -23,6 +23,9 @@ public class JpaMain {
             member.setUserName("hello1");
             member.setHomeAddress(address);
             em.persist(member);
+            Address address2 = new Address("city2","street","zipcode");
+            member.setHomeAddress(address2);
+
 
             Address copyAddress = new Address(address.getCity(), address.getStreet(),
                 address.getZipcode());
@@ -31,7 +34,7 @@ public class JpaMain {
             member2.setHomeAddress(copyAddress);
             em.persist(member2);
 
-            member.getHomeAddress().setCity("newCity");
+
             tx.commit();
         }catch(Exception e){
             e.printStackTrace();

--- a/jpa-study/src/main/java/com/hellojpa/Member.java
+++ b/jpa-study/src/main/java/com/hellojpa/Member.java
@@ -1,7 +1,10 @@
 package com.hellojpa;
 
 import java.time.LocalDateTime;
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
 import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -11,28 +14,28 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 
 @Entity
-public class Member extends BaseEntity{
+public class Member{
     @Id @GeneratedValue
     @Column(name="MEMBER_ID")
     private Long id;
     @Column(name="USERNAME")
     private String userName;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="TEAM_ID")
-    private Team team;
+    //기간 Period
+    @Embedded
+    private Period workPeriod;
+    //주소
+    @Embedded
+    private Address homeAddress;
+//    @Embedded
+//    @AttributeOverrides({
+//        @AttributeOverride(name="city",column = @Column(name="WORK_CITY")),
+//        @AttributeOverride(name="street",column = @Column(name="WORK_STREET")),
+//        @AttributeOverride(name="zipcode",column = @Column(name="WORK_ZIPCODE"))
+//    })
+//    private Address workAddress;
 
-    public Member() {
-    }
 
-    public Team getTeam() {
-        return team;
-    }
-
-    public void setTeam(Team team) {
-        this.team = team;
-        team.getMembers().add(this);
-    }
 
     public Long getId() {
         return id;
@@ -50,5 +53,19 @@ public class Member extends BaseEntity{
         this.userName = userName;
     }
 
+    public Period getWorkPeriod() {
+        return workPeriod;
+    }
 
+    public void setWorkPeriod(Period workPeriod) {
+        this.workPeriod = workPeriod;
+    }
+
+    public Address getHomeAddress() {
+        return homeAddress;
+    }
+
+    public void setHomeAddress(Address homeAddress) {
+        this.homeAddress = homeAddress;
+    }
 }

--- a/jpa-study/src/main/java/com/hellojpa/Period.java
+++ b/jpa-study/src/main/java/com/hellojpa/Period.java
@@ -1,0 +1,34 @@
+package com.hellojpa;
+
+import java.time.LocalDateTime;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class Period {
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+    public Period() {
+    }
+
+    public Period(LocalDateTime startDate, LocalDateTime endDate) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public LocalDateTime getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(LocalDateTime startDate) {
+        this.startDate = startDate;
+    }
+
+    public LocalDateTime getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDateTime endDate) {
+        this.endDate = endDate;
+    }
+}

--- a/jpa-study/src/main/java/com/hellojpa/Team.java
+++ b/jpa-study/src/main/java/com/hellojpa/Team.java
@@ -15,8 +15,6 @@ public class Team extends BaseEntity{
     @Column(name = "TEAM_ID")
     private Long id;
     private String name;
-    @OneToMany(mappedBy = "team")
-    private List<Member> members = new ArrayList<>();
 
     public Long getId() {
         return id;
@@ -34,11 +32,4 @@ public class Team extends BaseEntity{
         this.name = name;
     }
 
-    public List<Member> getMembers() {
-        return members;
-    }
-
-    public void setMembers(List<Member> members) {
-        this.members = members;
-    }
 }

--- a/jpa-study/src/main/java/com/hellojpa/ValueMain.java
+++ b/jpa-study/src/main/java/com/hellojpa/ValueMain.java
@@ -1,0 +1,13 @@
+package com.hellojpa;
+
+public class ValueMain {
+
+    public static void main(String[] args) {
+
+        Integer a = new Integer(10);
+
+        System.out.println("a = " + a);
+        System.out.println("b = " + a);
+    }
+
+}


### PR DESCRIPTION
JPA 엔티티는 Primitive 타입과 객체 타입의 변수를 가질 수 있는데, 객체 타입의 경우(@Embedded)로 성질이 비슷한 컬럼들을 추상화해 객체로 가질 수 있다.(테이블 변화 없음) 이 때 주의사항이 멤버1,2가 같은 Address 인스턴스를 참조한다면 멤버1의 Address 내의 City를 변경 시 멤버 1,2 는 같이 바뀌게 된다. 생각해보면 당연하지만,,
Layer가 다르고 코드가 많다면 이건 눈으로 버그를 잡아낼 수 없다. 그렇기에 임베디드 타입을 변수로 갖게 한다면 불변객체로 만들어야한다. 생성자로만 값을 설정할 수 있게 하고, Setter 는 private 으로 막으면 된다.