### PR TITLE
#32 - 값타입2, 값 타입 컬렉션

### DIFF
--- a/jpa-study/src/main/java/com/hellojpa/Address.java
+++ b/jpa-study/src/main/java/com/hellojpa/Address.java
@@ -1,5 +1,6 @@
 package com.hellojpa;
 
+import java.util.Objects;
 import javax.persistence.Embeddable;
 
 @Embeddable
@@ -41,5 +42,23 @@ public class Address {
 
     private void setZipcode(String zipcode) {
         this.zipcode = zipcode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Address address = (Address) o;
+        return Objects.equals(city, address.city) && Objects.equals(street,
+            address.street) && Objects.equals(zipcode, address.zipcode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(city, street, zipcode);
     }
 }

--- a/jpa-study/src/main/java/com/hellojpa/AddressEntity.java
+++ b/jpa-study/src/main/java/com/hellojpa/AddressEntity.java
@@ -1,0 +1,57 @@
+package com.hellojpa;
+
+import java.util.Objects;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name="ADDRESS")
+public class AddressEntity {
+    @Id @GeneratedValue
+    private Long id;
+    @Embedded
+    private Address address;
+
+    public AddressEntity() {
+    }
+
+    public AddressEntity(Address address) {
+        this.address = address;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AddressEntity that = (AddressEntity) o;
+        return Objects.equals(id, that.id) && Objects.equals(address, that.address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, address);
+    }
+}

--- a/jpa-study/src/main/java/com/hellojpa/JpaMain.java
+++ b/jpa-study/src/main/java/com/hellojpa/JpaMain.java
@@ -2,6 +2,7 @@ package com.hellojpa;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -18,22 +19,49 @@ public class JpaMain {
         EntityTransaction tx = em.getTransaction();
         tx.begin();
         try{
-            Address address = new Address("city","street","zipcode");
             Member member = new Member();
-            member.setUserName("hello1");
-            member.setHomeAddress(address);
+            member.setUserName("member1");
+            member.setHomeAddress(new Address("homeCity","street1","10000"));
+
+            member.getFavoriteFoods().add("치킨");
+            member.getFavoriteFoods().add("족발");
+            member.getFavoriteFoods().add("피자");
+            AddressEntity addressEntity1 = new AddressEntity(
+                new Address("old1", "street1", "10000"));
+            member.getAddressHistory().add(addressEntity1);
+            member.getAddressHistory().add(new AddressEntity(new Address("old2","street1","10000")));
             em.persist(member);
-            Address address2 = new Address("city2","street","zipcode");
-            member.setHomeAddress(address2);
 
-
-            Address copyAddress = new Address(address.getCity(), address.getStreet(),
-                address.getZipcode());
-            Member member2 = new Member();
-            member2.setUserName("hello1");
-            member2.setHomeAddress(copyAddress);
-            em.persist(member2);
-
+            em.flush();
+            em.clear();
+            System.out.println("====================================");
+            Member findMember = em.find(Member.class, member.getId());
+            List<AddressEntity> addressHistory = findMember.getAddressHistory();
+            System.out.println(addressHistory.getClass());
+//            System.out.println("===============AddressHistory 값 사용=================");
+//            for (AddressEntity address : addressHistory) {
+//                System.out.println("address = " + address);
+//            }
+//
+//            Set<String> favoriteFoods = findMember.getFavoriteFoods();
+//            System.out.println("===============favorite Foods 값 사용=================");
+//            for (String favoriteFood : favoriteFoods) {
+//                System.out.println("favoriteFood = " + favoriteFood);
+//            }
+            // homeCity -> newCity
+            // 값타입은 불변객체로 해야하기때문에 findMember.getHomeAddress().setCity("newCity") 절대 금지
+            // 물론 set 은 막아놨지만 저렇게 접근하면 안된다.(사이드이펙트 문제) 통째로 갈아껴야함.
+//            Address oldAddres = findMember.getHomeAddress();
+//            findMember.setHomeAddress(new Address("newCIty", oldAddres.getStreet(),
+//                oldAddres.getZipcode()));
+//
+//            //치킨 -> 한식
+//            findMember.getFavoriteFoods().remove("치킨");
+//            findMember.getFavoriteFoods().add("한식");
+            System.out.println("====================================");
+            findMember.getAddressHistory().remove(addressEntity1);
+            System.out.println("====================================");
+            findMember.getAddressHistory().add(new AddressEntity(new Address("newCity1","street1","10000")));
 
             tx.commit();
         }catch(Exception e){

--- a/jpa-study/src/main/java/com/hellojpa/Member.java
+++ b/jpa-study/src/main/java/com/hellojpa/Member.java
@@ -1,17 +1,20 @@
 package com.hellojpa;
 
-import java.time.LocalDateTime;
-import javax.persistence.AttributeOverride;
-import javax.persistence.AttributeOverrides;
+import static javax.persistence.CascadeType.ALL;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.persistence.CollectionTable;
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
+import javax.persistence.OneToMany;
 
 @Entity
 public class Member{
@@ -20,10 +23,18 @@ public class Member{
     private Long id;
     @Column(name="USERNAME")
     private String userName;
+    @ElementCollection
+    @CollectionTable(name="FAVORITE_FOOD",joinColumns = @JoinColumn(name="MEMBER_ID"))
+    @Column(name="FOOD_NAME")
+    private Set<String> favoriteFoods = new HashSet<>();
 
-    //기간 Period
-    @Embedded
-    private Period workPeriod;
+    @OneToMany(cascade = ALL,orphanRemoval = true)
+    @JoinColumn(name="MEMBER_ID")
+    private List<AddressEntity> addressHistory = new ArrayList<>();
+
+//    @ElementCollection
+//    @CollectionTable(name="ADDRESS",joinColumns = @JoinColumn(name="MEMBER_ID"))
+//    private List<Address> addressHistory = new ArrayList<>();
     //주소
     @Embedded
     private Address homeAddress;
@@ -53,13 +64,7 @@ public class Member{
         this.userName = userName;
     }
 
-    public Period getWorkPeriod() {
-        return workPeriod;
-    }
 
-    public void setWorkPeriod(Period workPeriod) {
-        this.workPeriod = workPeriod;
-    }
 
     public Address getHomeAddress() {
         return homeAddress;
@@ -67,5 +72,21 @@ public class Member{
 
     public void setHomeAddress(Address homeAddress) {
         this.homeAddress = homeAddress;
+    }
+
+    public Set<String> getFavoriteFoods() {
+        return favoriteFoods;
+    }
+
+    public void setFavoriteFoods(Set<String> favoriteFoods) {
+        this.favoriteFoods = favoriteFoods;
+    }
+
+    public List<AddressEntity> getAddressHistory() {
+        return addressHistory;
+    }
+
+    public void setAddressHistory(List<AddressEntity> addressHistory) {
+        this.addressHistory = addressHistory;
     }
 }


### PR DESCRIPTION
this closes #32 
컬렉션의 경우 remove 의 equals는 기본 동일성 비교이기 때문에 지워지지 않는다. 해당 객체의 equals, hash 를 오버라이드 해서 remove를 해야 정상적으로 컬렉션에서 지워지고 db에 delete 쿼리를 날리게 된다.

값타입 컬렉션의 값을 지우는 경우에 식별할 수 있는 값이 없기 때문에 참조하는 Member_ID 의 Address를 DB에서 다 지우고 바뀐 컬렉션을 다시 insert 하게된다. 이런 이슈로 인해 Address -> AddressEntity로 엔티티로 만들어 AddressEntity가 Address 값타입을 가지게 만들어서 식별자를 가지게 만들었고, Member쪽에 @OneToMany 단방향 연관관계를 가지게 함 관계의 주인이 Member쪽이라 insert 할때 Address 쪽에 update MEMBER_ID를 하는 단점이 있지만 이렇게 사용하는게 옳다.

자세한 내용은 issue #32 확인하자.